### PR TITLE
Feature/230127 close get method for extends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - New tuple of N elements, just interface.
 - New abstraction for all tuples `AbstractTuple`.
 - Basic realization of method `toString()` for all tuples.
+- New Utility class for the checking index bounds.
 
 ## [0.2.3] - 2023-01-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 - Basic realization of method `toString()` for all tuples.
 - New Utility class for the checking index bounds.
 
+### Changed
+
+- Method `get()` realization for all Tuple realizations to `final`.
+- Method `size()` realization for all Tuple realizations to `final`.
+
 ## [0.2.3] - 2023-01-09
 
 ### Added

--- a/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Couple.java
+++ b/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Couple.java
@@ -90,7 +90,7 @@ public class Couple<A, B>
      * range ({@code index < 0 || index >= size()})
      */
     @Override
-    public Object get(int index) {
+    public final Object get(int index) {
         if (IndexBounds.requireIndexWithinBounds(index, this.size()) == 0) {
             return this.t0;
         }

--- a/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/EmptyTuple.java
+++ b/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/EmptyTuple.java
@@ -62,7 +62,7 @@ public class EmptyTuple
      * @throws IndexOutOfBoundsException for all method {@code get} invocations
      */
     @Override
-    public Object get(int index) {
+    public final Object get(int index) {
         return IndexBounds.requireIndexWithinBounds(index, this.size());
     }
 
@@ -81,7 +81,7 @@ public class EmptyTuple
      * type for this {@code defaultValue}
      */
     @Override
-    public Object getOrDefault(int index, Object defaultValue) {
+    public final Object getOrDefault(int index, Object defaultValue) {
         return defaultValue;
     }
 

--- a/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Monuple.java
+++ b/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Monuple.java
@@ -80,7 +80,7 @@ public class Monuple<A>
      * range ({@code index < 0 || index >= size()})
      */
     @Override
-    public Object get(int index) {
+    public final Object get(int index) {
         IndexBounds.requireIndexWithinBounds(index, this.size());
 
         return this.t0;

--- a/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Octuple.java
+++ b/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Octuple.java
@@ -137,7 +137,7 @@ public class Octuple<A, B, C, D, E, F, G, H>
      * range ({@code index < 0 || index >= size()})
      */
     @Override
-    public Object get(int index) {
+    public final Object get(int index) {
         switch (IndexBounds.requireIndexWithinBounds(index, this.size())) {
             case 0:
                 return this.t0;

--- a/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Quadruple.java
+++ b/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Quadruple.java
@@ -105,7 +105,7 @@ public class Quadruple<A, B, C, D>
      * range ({@code index < 0 || index >= size()})
      */
     @Override
-    public Object get(int index) {
+    public final Object get(int index) {
         switch (IndexBounds.requireIndexWithinBounds(index, this.size())) {
             case 0:
                 return this.t0;

--- a/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Quintuple.java
+++ b/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Quintuple.java
@@ -113,7 +113,7 @@ public class Quintuple<A, B, C, D, E>
      * range ({@code index < 0 || index >= size()})
      */
     @Override
-    public Object get(int index) {
+    public final Object get(int index) {
         switch (IndexBounds.requireIndexWithinBounds(index, this.size())) {
             case 0:
                 return this.t0;

--- a/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Septuple.java
+++ b/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Septuple.java
@@ -129,7 +129,7 @@ public class Septuple<A, B, C, D, E, F, G>
      * range ({@code index < 0 || index >= size()})
      */
     @Override
-    public Object get(int index) {
+    public final Object get(int index) {
         switch (IndexBounds.requireIndexWithinBounds(index, this.size())) {
             case 0:
                 return this.t0;

--- a/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Sextuple.java
+++ b/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Sextuple.java
@@ -121,7 +121,7 @@ public class Sextuple<A, B, C, D, E, F>
      * range ({@code index < 0 || index >= size()})
      */
     @Override
-    public Object get(int index) {
+    public final Object get(int index) {
         switch (IndexBounds.requireIndexWithinBounds(index, this.size())) {
             case 0:
                 return this.t0;

--- a/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Triple.java
+++ b/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Triple.java
@@ -97,7 +97,7 @@ public class Triple<A, B, C>
      * range ({@code index < 0 || index >= size()})
      */
     @Override
-    public Object get(int index) {
+    public final Object get(int index) {
         switch (IndexBounds.requireIndexWithinBounds(index, this.size())) {
             case 0:
                 return this.t0;


### PR DESCRIPTION
### Changed

- Method `get()` realization for all Tuple realizations to `final`.
- Method `size()` realization for all Tuple realizations to `final`.