### PR TITLE
Feature/moonshine tuple add map methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - yyyy-mm-dd
+
+### Added
+
+- New method stream() has been added to the Tuple collection, which allows creating a new stream
+from a Tuple object. The similar method toStream() has been deprecated and will be removed in upcoming releases.
 
 ## [0.8.2] - 2023-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - yyyy-mm-dd
 
+## [0.9.0-SNAPSHOT] - 2023-07-06
+
 ### Added
 
 - New method stream() has been added to the Tuple collection, which allows creating a new stream

--- a/moonshine-bom/pom.xml
+++ b/moonshine-bom/pom.xml
@@ -23,7 +23,7 @@
     <!--<artifact-->
     <groupId>io.github.ololx.moonshine</groupId>
     <artifactId>moonshine-bom</artifactId>
-    <version>0.8.2-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <!--artifact>-->
 

--- a/moonshine-bytes/pom.xml
+++ b/moonshine-bytes/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>moonshine</artifactId>
         <groupId>io.github.ololx.moonshine</groupId>
-        <version>0.8.2-SNAPSHOT</version>
+        <version>0.9.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <!--parent>-->

--- a/moonshine-measuring/pom.xml
+++ b/moonshine-measuring/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <artifactId>moonshine</artifactId>
         <groupId>io.github.ololx.moonshine</groupId>
-        <version>0.8.2-SNAPSHOT</version>
+        <version>0.9.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <!--parent>-->

--- a/moonshine-stopwatch/pom.xml
+++ b/moonshine-stopwatch/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>moonshine</artifactId>
         <groupId>io.github.ololx.moonshine</groupId>
-        <version>0.8.2-SNAPSHOT</version>
+        <version>0.9.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <!--parent>-->

--- a/moonshine-tuple/pom.xml
+++ b/moonshine-tuple/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <artifactId>moonshine</artifactId>
         <groupId>io.github.ololx.moonshine</groupId>
-        <version>0.8.2-SNAPSHOT</version>
+        <version>0.9.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <!--parent>-->

--- a/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Tuple.java
+++ b/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Tuple.java
@@ -248,6 +248,9 @@ public interface Tuple extends Iterable<Object> {
     }
 
     /**
+     * This method is deprecated and will be removed in a future releases;
+     * use {@code stream()} instead.
+     *
      * Returns a {@code Stream<Object>} stream containing all the elements in
      * this tuple in proper sequence (from first to last element).
      *
@@ -264,9 +267,33 @@ public interface Tuple extends Iterable<Object> {
      * @return a {@code Stream<Object>} stream containing all the elements in
      * this tuple in proper sequence
      */
+    @Deprecated
     default Stream<Object> toStream() {
         return IntStream.range(0, this.size())
                 .mapToObj(this::get);
+    }
+
+    /**
+     * Returns a {@code Stream<Object>} stream containing all the elements in
+     * this tuple in proper sequence (from first to last element).
+     *
+     * @implSpec
+     * The returned {@code Stream<Object>} stream will be "safe" in that no
+     * references to it are maintained by this tuple.  (In other words, this
+     * method must allocate a new {@code Stream<Object>} stream). The caller
+     * is thus free to modify the returned {@code Stream<Object>} stream.
+     *
+     * <br/>
+     * This method acts as bridge between array-based, collection-based
+     * and tuple-based APIs.
+     *
+     * @return a {@code Stream<Object>} stream containing all the elements in
+     * this tuple in proper sequence
+     */
+    @Deprecated
+    default Stream<Object> stream() {
+        return IntStream.range(0, this.size())
+            .mapToObj(this::get);
     }
 
     /**

--- a/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Tuple.java
+++ b/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Tuple.java
@@ -21,6 +21,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import static java.util.Spliterator.*;
 
@@ -291,8 +292,7 @@ public interface Tuple extends Iterable<Object> {
      * this tuple in proper sequence
      */
     default Stream<Object> stream() {
-        return IntStream.range(0, this.size())
-            .mapToObj(this::get);
+        return StreamSupport.stream(this.spliterator(), false);
     }
 
     /**

--- a/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Tuple.java
+++ b/moonshine-tuple/src/main/java/io/github/ololx/moonshine/tuple/Tuple.java
@@ -290,7 +290,6 @@ public interface Tuple extends Iterable<Object> {
      * @return a {@code Stream<Object>} stream containing all the elements in
      * this tuple in proper sequence
      */
-    @Deprecated
     default Stream<Object> stream() {
         return IntStream.range(0, this.size())
             .mapToObj(this::get);

--- a/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/CoupleTest.java
+++ b/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/CoupleTest.java
@@ -286,14 +286,14 @@ public class CoupleTest {
     }
 
     @Test(dataProvider = "providesConstructorArgs")
-    <A, B> void toStream_whenBuildStream_thenStreamContainsAllElements(A t0, B t1) {
+    <A, B> void stream_whenBuildStream_thenStreamContainsAllElements(A t0, B t1) {
         //Given
         // The tuple with args
         Couple<A, B> tuple = new Couple<>(t0, t1);
 
         //When
         // build list from this tuple
-        Stream<Object> tupleInStream = tuple.toStream();
+        Stream<Object> tupleInStream = tuple.stream();
 
         //Then
         // list contains all tuple values

--- a/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/EmptyTupleTest.java
+++ b/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/EmptyTupleTest.java
@@ -182,14 +182,14 @@ public class EmptyTupleTest {
     }
 
     @Test
-    void toStream_whenBuildStream_thenStreamContainsAllElements() {
+    void stream_whenBuildStream_thenStreamContainsAllElements() {
         //Given
         // The tuple with args
         EmptyTuple tuple = new EmptyTuple();
 
         //When
         // build stream from this tuple
-        Stream<Object> tupleInStream = tuple.toStream();
+        Stream<Object> tupleInStream = tuple.stream();
 
         //Then
         // stream is empty

--- a/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/MonupleTest.java
+++ b/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/MonupleTest.java
@@ -324,14 +324,14 @@ public class MonupleTest {
     }
 
     @Test(dataProvider = "providesConstructorArgs")
-    <A> void toStream_whenBuildStream_thenStreamContainsAllElements(A t0) {
+    <A> void stream_whenBuildStream_thenStreamContainsAllElements(A t0) {
         //Given
         // The tuple with args
         Monuple<A> tuple = new Monuple<>(t0);
 
         //When
         // build list from this tuple
-        Stream<Object> tupleInStream = tuple.toStream();
+        Stream<Object> tupleInStream = tuple.stream();
 
         //Then
         // list contains all tuple values

--- a/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/OctupleTest.java
+++ b/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/OctupleTest.java
@@ -557,7 +557,7 @@ public class OctupleTest {
     }
 
     @Test(dataProvider = "providesConstructorArgs")
-    <A, B, C, D, E, F, G, H> void toStream_whenBuildStream_thenStreamContainsAllElements(A t0,
+    <A, B, C, D, E, F, G, H> void stream_whenBuildStream_thenStreamContainsAllElements(A t0,
                                                                                          B t1,
                                                                                          C t2,
                                                                                          D t3,
@@ -571,7 +571,7 @@ public class OctupleTest {
 
         //When
         // build list from this tuple
-        Stream<Object> tupleInStream = tuple.toStream();
+        Stream<Object> tupleInStream = tuple.stream();
 
         //Then
         // list contains all tuple values

--- a/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/QuadrupleTest.java
+++ b/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/QuadrupleTest.java
@@ -338,7 +338,7 @@ public class QuadrupleTest {
     }
 
     @Test(dataProvider = "providesConstructorArgs")
-    <A, B, C, D> void toStream_whenBuildStream_thenStreamContainsAllElements(A t0, 
+    <A, B, C, D> void stream_whenBuildStream_thenStreamContainsAllElements(A t0, 
                                                                              B t1, 
                                                                              C t2, 
                                                                              D t3) {
@@ -348,7 +348,7 @@ public class QuadrupleTest {
 
         //When
         // build list from this tuple
-        Stream<Object> tupleInStream = tuple.toStream();
+        Stream<Object> tupleInStream = tuple.stream();
 
         //Then
         // list contains all tuple values

--- a/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/QuintupleTest.java
+++ b/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/QuintupleTest.java
@@ -391,7 +391,7 @@ public class QuintupleTest {
     }
 
     @Test(dataProvider = "providesConstructorArgs")
-    <A, B, C, D, E> void toStream_whenBuildStream_thenStreamContainsAllElements(A t0,
+    <A, B, C, D, E> void stream_whenBuildStream_thenStreamContainsAllElements(A t0,
                                                                                 B t1,
                                                                                 C t2,
                                                                                 D t3,
@@ -402,7 +402,7 @@ public class QuintupleTest {
 
         //When
         // build list from this tuple
-        Stream<Object> tupleInStream = tuple.toStream();
+        Stream<Object> tupleInStream = tuple.stream();
 
         //Then
         // list contains all tuple values

--- a/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/SeptupleTest.java
+++ b/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/SeptupleTest.java
@@ -509,7 +509,7 @@ public class SeptupleTest {
     }
 
     @Test(dataProvider = "providesConstructorArgs")
-    <A, B, C, D, E, F, G> void toStream_whenBuildStream_thenStreamContainsAllElements(A t0,
+    <A, B, C, D, E, F, G> void stream_whenBuildStream_thenStreamContainsAllElements(A t0,
                                                                                       B t1,
                                                                                       C t2,
                                                                                       D t3,
@@ -522,7 +522,7 @@ public class SeptupleTest {
 
         //When
         // build list from this tuple
-        Stream<Object> tupleInStream = tuple.toStream();
+        Stream<Object> tupleInStream = tuple.stream();
 
         //Then
         // list contains all tuple values

--- a/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/SextupleTest.java
+++ b/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/SextupleTest.java
@@ -463,7 +463,7 @@ public class SextupleTest {
     }
 
     @Test(dataProvider = "providesConstructorArgs")
-    <A, B, C, D, E, F> void toStream_whenBuildStream_thenStreamContainsAllElements(A t0,
+    <A, B, C, D, E, F> void stream_whenBuildStream_thenStreamContainsAllElements(A t0,
                                                                                    B t1,
                                                                                    C t2,
                                                                                    D t3,
@@ -475,7 +475,7 @@ public class SextupleTest {
 
         //When
         // build list from this tuple
-        Stream<Object> tupleInStream = tuple.toStream();
+        Stream<Object> tupleInStream = tuple.stream();
 
         //Then
         // list contains all tuple values

--- a/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/TripleTest.java
+++ b/moonshine-tuple/src/test/java/io/github/ololx/moonshine/tuple/TripleTest.java
@@ -309,14 +309,14 @@ public class TripleTest {
     }
 
     @Test(dataProvider = "providesConstructorArgs")
-    <A, B, C> void toStream_whenBuildStream_thenStreamContainsAllElements(A t0, B t1, C t2) {
+    <A, B, C> void stream_whenBuildStream_thenStreamContainsAllElements(A t0, B t1, C t2) {
         //Given
         // The tuple with args
         Triple<A, B, C> tuple = new Triple<>(t0, t1, t2);
 
         //When
         // build list from this tuple
-        Stream<Object> tupleInStream = tuple.toStream();
+        Stream<Object> tupleInStream = tuple.stream();
 
         //Then
         // list contains all tuple values

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <!--<artifact-->
     <groupId>io.github.ololx.moonshine</groupId>
     <artifactId>moonshine</artifactId>
-    <version>0.8.2-SNAPSHOT</version>
+    <version>0.9.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <!--artifact>-->
 


### PR DESCRIPTION
## [0.9.0-SNAPSHOT] - 2023-07-06

### Added

- New method stream() has been added to the Tuple collection, which allows creating a new stream
from a Tuple object. The similar method toStream() has been deprecated and will be removed in upcoming releases.